### PR TITLE
Bring JSON format in line by changing formatted to displayOnly to con…

### DIFF
--- a/docs/classes/Doubloon.md
+++ b/docs/classes/Doubloon.md
@@ -6,7 +6,7 @@
 
 # Class: Doubloon\<T\>
 
-Defined in: [Doubloon.ts:10](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L10)
+Defined in: [Doubloon.ts:10](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L10)
 
 ## Type Parameters
 
@@ -20,7 +20,7 @@ Defined in: [Doubloon.ts:10](https://github.com/HitchPin/doubloon-ts/blob/d49b16
 
 > **new Doubloon**\<`T`\>(`currency`, `value`, `sigil`?): `Doubloon`\<`T`\>
 
-Defined in: [Doubloon.ts:23](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L23)
+Defined in: [Doubloon.ts:23](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L23)
 
 Instantiate a monetary value in a given currency.
 
@@ -54,7 +54,7 @@ internal use, it allows for maintaining precision while doing long calculations.
 
 > `readonly` **currency**: `T`
 
-Defined in: [Doubloon.ts:14](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L14)
+Defined in: [Doubloon.ts:14](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L14)
 
 ## Methods
 
@@ -62,7 +62,7 @@ Defined in: [Doubloon.ts:14](https://github.com/HitchPin/doubloon-ts/blob/d49b16
 
 > **add**(`value`): `Doubloon`\<`T`\>
 
-Defined in: [Doubloon.ts:44](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L44)
+Defined in: [Doubloon.ts:44](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L44)
 
 Add to another doubloon
 
@@ -86,7 +86,7 @@ a new doubloon with the sum total of this doubloon and the other doubloon
 
 > **div**(`value`): `Doubloon`\<`T`\>
 
-Defined in: [Doubloon.ts:109](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L109)
+Defined in: [Doubloon.ts:109](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L109)
 
 Divide this doubloon by a scalar value.
 
@@ -110,7 +110,7 @@ the divisor
 
 > **eq**(`value`): `boolean`
 
-Defined in: [Doubloon.ts:136](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L136)
+Defined in: [Doubloon.ts:136](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L136)
 
 Check if another doubloon instance is equal to this one.
 
@@ -134,7 +134,7 @@ another doubloon to check equality with
 
 > **format**(): `string`
 
-Defined in: [Doubloon.ts:222](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L222)
+Defined in: [Doubloon.ts:222](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L222)
 
 Produces a formatted string representation of the monetary value that this
 doubloon represents that is useful for display purposes - that is, it includes
@@ -153,7 +153,7 @@ symbols as needed.
 
 > **gt**(`value`): `boolean`
 
-Defined in: [Doubloon.ts:150](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L150)
+Defined in: [Doubloon.ts:150](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L150)
 
 Check if this doubloon has a value greater than another doubloon
 
@@ -177,7 +177,7 @@ if our value exceeds theirs
 
 > **gte**(`value`): `boolean`
 
-Defined in: [Doubloon.ts:164](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L164)
+Defined in: [Doubloon.ts:164](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L164)
 
 Check if this doubloon has a value greater than or equal to another doubloon
 
@@ -201,7 +201,7 @@ true if our value exceeds or matches theirs
 
 > **lt**(`value`): `boolean`
 
-Defined in: [Doubloon.ts:178](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L178)
+Defined in: [Doubloon.ts:178](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L178)
 
 Check if this doubloon has a value less than another doubloon
 
@@ -225,7 +225,7 @@ if our value preceeds theirs
 
 > **lte**(`value`): `boolean`
 
-Defined in: [Doubloon.ts:192](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L192)
+Defined in: [Doubloon.ts:192](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L192)
 
 Check if this doubloon has a value less than or equal to another doubloon
 
@@ -249,7 +249,7 @@ true if our value preceeds or matches theirs
 
 > **mul**(`value`): `Doubloon`\<`T`\>
 
-Defined in: [Doubloon.ts:82](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L82)
+Defined in: [Doubloon.ts:82](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L82)
 
 Multiply this doubloon by a scalar (i.e. non-Doubloon) value.
 For precision reasons, it must either be an integer number,
@@ -275,7 +275,7 @@ a new doubloon with the multiplied value
 
 > **quantize**(`roundingMode`): `Doubloon`\<`T`\>
 
-Defined in: [Doubloon.ts:201](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L201)
+Defined in: [Doubloon.ts:201](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L201)
 
 #### Parameters
 
@@ -293,7 +293,7 @@ Defined in: [Doubloon.ts:201](https://github.com/HitchPin/doubloon-ts/blob/d49b1
 
 > **str**(): `string`
 
-Defined in: [Doubloon.ts:211](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L211)
+Defined in: [Doubloon.ts:211](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L211)
 
 Extracts the value out of this doubloon in string form, quantized (i.e. rounded)
 according to the currency's requirements. Note however that no currency symbol is
@@ -311,7 +311,7 @@ a string representation of the value stored in this doubloon
 
 > **sub**(`value`): `Doubloon`\<`T`\>
 
-Defined in: [Doubloon.ts:62](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L62)
+Defined in: [Doubloon.ts:62](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L62)
 
 Subtract from this doubloon
 
@@ -335,7 +335,7 @@ a new doubloon with the subtracted value
 
 > **toJSON**(): [`DoubloonToJSON`](../type-aliases/DoubloonToJSON.md)
 
-Defined in: [Doubloon.ts:238](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L238)
+Defined in: [Doubloon.ts:238](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L238)
 
 Serialize this doubloon into the proper format for transmission over the wire to another
 doubloon-aware service.
@@ -352,7 +352,7 @@ a JSON object that should be treated opaquely
 
 > **toString**(): `string`
 
-Defined in: [Doubloon.ts:230](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L230)
+Defined in: [Doubloon.ts:230](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L230)
 
 Produces a developer-formatted representation of this doubloon instance
 to identify this value in the Chrome dev tools or other debugging environments.
@@ -369,7 +369,7 @@ a developer-oriented string formatting of this doubloon
 
 > `static` **parse**(`json`): `Doubloon`\<[`Currency`](../doubloons/namespaces/currencies/interfaces/Currency.md)\>
 
-Defined in: [Doubloon.ts:252](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L252)
+Defined in: [Doubloon.ts:252](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L252)
 
 Parses a JSON serialized doubloon back into a doubloon type of unknown currency.
 

--- a/docs/doubloons/namespaces/currencies/classes/CAD.md
+++ b/docs/doubloons/namespaces/currencies/classes/CAD.md
@@ -6,7 +6,7 @@
 
 # Class: CAD
 
-Defined in: [currency.ts:130](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L130)
+Defined in: [currency.ts:130](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L130)
 
 A base currency type that takes care of the most common
 needs of all currencies - properly handling rounding to the
@@ -23,7 +23,7 @@ and formatting.
 
 > **new CAD**(): `CAD`
 
-Defined in: [currency.ts:131](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L131)
+Defined in: [currency.ts:131](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L131)
 
 #### Returns
 
@@ -39,7 +39,7 @@ Defined in: [currency.ts:131](https://github.com/HitchPin/doubloon-ts/blob/d49b1
 
 > `readonly` **name**: `string`
 
-Defined in: [currency.ts:75](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L75)
+Defined in: [currency.ts:75](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L75)
 
 ISO 4217 Currency Code
 
@@ -55,7 +55,7 @@ ISO 4217 Currency Code
 
 > **get** **decimalPlaces**(): `number`
 
-Defined in: [currency.ts:83](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L83)
+Defined in: [currency.ts:83](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L83)
 
 Number of decimal places. Usually 2 (for cents).
 
@@ -73,7 +73,7 @@ Number of decimal places. Usually 2 (for cents).
 
 > **format**(`value`): `string`
 
-Defined in: [currency.ts:135](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L135)
+Defined in: [currency.ts:135](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L135)
 
 Format with appropriate symbol. For display only.
 
@@ -97,7 +97,7 @@ Format with appropriate symbol. For display only.
 
 > **quantize**(`value`, `rounding`?): `Decimal`
 
-Defined in: [currency.ts:88](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L88)
+Defined in: [currency.ts:88](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L88)
 
 Quantize to the correct decimal places. Only for internal use.
 
@@ -125,7 +125,7 @@ Quantize to the correct decimal places. Only for internal use.
 
 > **toDecimal**(`value`): `Decimal`
 
-Defined in: [currency.ts:95](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L95)
+Defined in: [currency.ts:95](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L95)
 
 A function that gets a decimal value from a decimal or string.
 

--- a/docs/doubloons/namespaces/currencies/classes/CVE.md
+++ b/docs/doubloons/namespaces/currencies/classes/CVE.md
@@ -6,7 +6,7 @@
 
 # Class: CVE
 
-Defined in: [currency.ts:152](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L152)
+Defined in: [currency.ts:152](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L152)
 
 A base currency type that takes care of the most common
 needs of all currencies - properly handling rounding to the
@@ -23,7 +23,7 @@ and formatting.
 
 > **new CVE**(): `CVE`
 
-Defined in: [currency.ts:153](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L153)
+Defined in: [currency.ts:153](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L153)
 
 #### Returns
 
@@ -39,7 +39,7 @@ Defined in: [currency.ts:153](https://github.com/HitchPin/doubloon-ts/blob/d49b1
 
 > `readonly` **name**: `string`
 
-Defined in: [currency.ts:75](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L75)
+Defined in: [currency.ts:75](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L75)
 
 ISO 4217 Currency Code
 
@@ -55,7 +55,7 @@ ISO 4217 Currency Code
 
 > **get** **decimalPlaces**(): `number`
 
-Defined in: [currency.ts:83](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L83)
+Defined in: [currency.ts:83](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L83)
 
 Number of decimal places. Usually 2 (for cents).
 
@@ -73,7 +73,7 @@ Number of decimal places. Usually 2 (for cents).
 
 > **format**(`value`): `string`
 
-Defined in: [currency.ts:157](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L157)
+Defined in: [currency.ts:157](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L157)
 
 Format with appropriate symbol. For display only.
 
@@ -97,7 +97,7 @@ Format with appropriate symbol. For display only.
 
 > **quantize**(`value`, `rounding`?): `Decimal`
 
-Defined in: [currency.ts:88](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L88)
+Defined in: [currency.ts:88](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L88)
 
 Quantize to the correct decimal places. Only for internal use.
 
@@ -125,7 +125,7 @@ Quantize to the correct decimal places. Only for internal use.
 
 > **toDecimal**(`value`): `Decimal`
 
-Defined in: [currency.ts:95](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L95)
+Defined in: [currency.ts:95](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L95)
 
 A function that gets a decimal value from a decimal or string.
 

--- a/docs/doubloons/namespaces/currencies/classes/EUR.md
+++ b/docs/doubloons/namespaces/currencies/classes/EUR.md
@@ -6,7 +6,7 @@
 
 # Class: EUR
 
-Defined in: [currency.ts:141](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L141)
+Defined in: [currency.ts:141](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L141)
 
 A base currency type that takes care of the most common
 needs of all currencies - properly handling rounding to the
@@ -23,7 +23,7 @@ and formatting.
 
 > **new EUR**(): `EUR`
 
-Defined in: [currency.ts:142](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L142)
+Defined in: [currency.ts:142](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L142)
 
 #### Returns
 
@@ -39,7 +39,7 @@ Defined in: [currency.ts:142](https://github.com/HitchPin/doubloon-ts/blob/d49b1
 
 > `readonly` **name**: `string`
 
-Defined in: [currency.ts:75](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L75)
+Defined in: [currency.ts:75](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L75)
 
 ISO 4217 Currency Code
 
@@ -55,7 +55,7 @@ ISO 4217 Currency Code
 
 > **get** **decimalPlaces**(): `number`
 
-Defined in: [currency.ts:83](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L83)
+Defined in: [currency.ts:83](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L83)
 
 Number of decimal places. Usually 2 (for cents).
 
@@ -73,7 +73,7 @@ Number of decimal places. Usually 2 (for cents).
 
 > **format**(`value`): `string`
 
-Defined in: [currency.ts:146](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L146)
+Defined in: [currency.ts:146](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L146)
 
 Format with appropriate symbol. For display only.
 
@@ -97,7 +97,7 @@ Format with appropriate symbol. For display only.
 
 > **quantize**(`value`, `rounding`?): `Decimal`
 
-Defined in: [currency.ts:88](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L88)
+Defined in: [currency.ts:88](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L88)
 
 Quantize to the correct decimal places. Only for internal use.
 
@@ -125,7 +125,7 @@ Quantize to the correct decimal places. Only for internal use.
 
 > **toDecimal**(`value`): `Decimal`
 
-Defined in: [currency.ts:95](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L95)
+Defined in: [currency.ts:95](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L95)
 
 A function that gets a decimal value from a decimal or string.
 

--- a/docs/doubloons/namespaces/currencies/classes/QuantizedCurrency.md
+++ b/docs/doubloons/namespaces/currencies/classes/QuantizedCurrency.md
@@ -6,7 +6,7 @@
 
 # Class: `abstract` QuantizedCurrency
 
-Defined in: [currency.ts:73](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L73)
+Defined in: [currency.ts:73](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L73)
 
 A base currency type that takes care of the most common
 needs of all currencies - properly handling rounding to the
@@ -30,7 +30,7 @@ and formatting.
 
 > **new QuantizedCurrency**(`name`, `precision`): `QuantizedCurrency`
 
-Defined in: [currency.ts:77](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L77)
+Defined in: [currency.ts:77](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L77)
 
 #### Parameters
 
@@ -52,7 +52,7 @@ Defined in: [currency.ts:77](https://github.com/HitchPin/doubloon-ts/blob/d49b16
 
 > `readonly` **name**: `string`
 
-Defined in: [currency.ts:75](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L75)
+Defined in: [currency.ts:75](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L75)
 
 ISO 4217 Currency Code
 
@@ -68,7 +68,7 @@ ISO 4217 Currency Code
 
 > **get** **decimalPlaces**(): `number`
 
-Defined in: [currency.ts:83](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L83)
+Defined in: [currency.ts:83](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L83)
 
 Number of decimal places. Usually 2 (for cents).
 
@@ -86,7 +86,7 @@ Number of decimal places. Usually 2 (for cents).
 
 > `abstract` **format**(`value`): `string`
 
-Defined in: [currency.ts:116](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L116)
+Defined in: [currency.ts:116](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L116)
 
 Format with appropriate symbol. For display only.
 
@@ -110,7 +110,7 @@ Format with appropriate symbol. For display only.
 
 > **quantize**(`value`, `rounding`?): `Decimal`
 
-Defined in: [currency.ts:88](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L88)
+Defined in: [currency.ts:88](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L88)
 
 Quantize to the correct decimal places. Only for internal use.
 
@@ -138,7 +138,7 @@ Quantize to the correct decimal places. Only for internal use.
 
 > **toDecimal**(`value`): `Decimal`
 
-Defined in: [currency.ts:95](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L95)
+Defined in: [currency.ts:95](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L95)
 
 A function that gets a decimal value from a decimal or string.
 

--- a/docs/doubloons/namespaces/currencies/classes/Registry.md
+++ b/docs/doubloons/namespaces/currencies/classes/Registry.md
@@ -6,7 +6,7 @@
 
 # Class: Registry
 
-Defined in: [currency.ts:34](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L34)
+Defined in: [currency.ts:34](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L34)
 
 For JSON deserialization of unknown currencies, we need a registry
 of all the known currencies. A singleton instance of the registry
@@ -28,7 +28,7 @@ class does the trick.
 
 > **byName**(`name`): [`CurrencyType`](../type-aliases/CurrencyType.md)\<[`Currency`](../interfaces/Currency.md)\>
 
-Defined in: [currency.ts:54](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L54)
+Defined in: [currency.ts:54](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L54)
 
 Lookup a currency type by name.
 
@@ -52,7 +52,7 @@ a generic constructor producing the requested currency.
 
 > **register**(`name`): `ClassDecorator`
 
-Defined in: [currency.ts:42](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L42)
+Defined in: [currency.ts:42](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L42)
 
 Register a currency class for availability in JSON deserialization.
 

--- a/docs/doubloons/namespaces/currencies/classes/USD.md
+++ b/docs/doubloons/namespaces/currencies/classes/USD.md
@@ -6,7 +6,7 @@
 
 # Class: USD
 
-Defined in: [currency.ts:120](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L120)
+Defined in: [currency.ts:120](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L120)
 
 A base currency type that takes care of the most common
 needs of all currencies - properly handling rounding to the
@@ -23,7 +23,7 @@ and formatting.
 
 > **new USD**(): `USD`
 
-Defined in: [currency.ts:121](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L121)
+Defined in: [currency.ts:121](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L121)
 
 #### Returns
 
@@ -39,7 +39,7 @@ Defined in: [currency.ts:121](https://github.com/HitchPin/doubloon-ts/blob/d49b1
 
 > `readonly` **name**: `string`
 
-Defined in: [currency.ts:75](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L75)
+Defined in: [currency.ts:75](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L75)
 
 ISO 4217 Currency Code
 
@@ -55,7 +55,7 @@ ISO 4217 Currency Code
 
 > **get** **decimalPlaces**(): `number`
 
-Defined in: [currency.ts:83](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L83)
+Defined in: [currency.ts:83](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L83)
 
 Number of decimal places. Usually 2 (for cents).
 
@@ -73,7 +73,7 @@ Number of decimal places. Usually 2 (for cents).
 
 > **format**(`value`): `string`
 
-Defined in: [currency.ts:125](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L125)
+Defined in: [currency.ts:125](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L125)
 
 Format with appropriate symbol. For display only.
 
@@ -97,7 +97,7 @@ Format with appropriate symbol. For display only.
 
 > **quantize**(`value`, `rounding`?): `Decimal`
 
-Defined in: [currency.ts:88](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L88)
+Defined in: [currency.ts:88](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L88)
 
 Quantize to the correct decimal places. Only for internal use.
 
@@ -125,7 +125,7 @@ Quantize to the correct decimal places. Only for internal use.
 
 > **toDecimal**(`value`): `Decimal`
 
-Defined in: [currency.ts:95](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L95)
+Defined in: [currency.ts:95](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L95)
 
 A function that gets a decimal value from a decimal or string.
 

--- a/docs/doubloons/namespaces/currencies/interfaces/Currency.md
+++ b/docs/doubloons/namespaces/currencies/interfaces/Currency.md
@@ -6,7 +6,7 @@
 
 # Interface: Currency
 
-Defined in: [currency.ts:8](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L8)
+Defined in: [currency.ts:8](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L8)
 
 Represents a type of world currency. Different currencies are considered
 different types that are in no way compatible with each other and should
@@ -18,7 +18,7 @@ disallow mathematical operations at the type level and at runtime.
 
 > `readonly` **name**: `string`
 
-Defined in: [currency.ts:10](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L10)
+Defined in: [currency.ts:10](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L10)
 
 ISO 4217 Currency Code
 
@@ -30,7 +30,7 @@ ISO 4217 Currency Code
 
 > **get** **decimalPlaces**(): `number`
 
-Defined in: [currency.ts:12](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L12)
+Defined in: [currency.ts:12](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L12)
 
 Number of decimal places. Usually 2 (for cents).
 
@@ -44,7 +44,7 @@ Number of decimal places. Usually 2 (for cents).
 
 > **format**(`value`): `string`
 
-Defined in: [currency.ts:21](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L21)
+Defined in: [currency.ts:21](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L21)
 
 Format with appropriate symbol. For display only.
 
@@ -64,7 +64,7 @@ Format with appropriate symbol. For display only.
 
 > **quantize**(`value`, `roundingMode`?): `Decimal`
 
-Defined in: [currency.ts:19](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L19)
+Defined in: [currency.ts:19](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L19)
 
 Quantize to the correct decimal places. Only for internal use.
 
@@ -88,7 +88,7 @@ Quantize to the correct decimal places. Only for internal use.
 
 > **toDecimal**(`value`): `Decimal`
 
-Defined in: [currency.ts:17](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L17)
+Defined in: [currency.ts:17](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L17)
 
 A function that gets a decimal value from a decimal or string.
 

--- a/docs/doubloons/namespaces/currencies/type-aliases/CurrencyType.md
+++ b/docs/doubloons/namespaces/currencies/type-aliases/CurrencyType.md
@@ -8,7 +8,7 @@
 
 > **CurrencyType**\<`T`\> = (...`parameters`) => `T`
 
-Defined in: [currency.ts:25](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L25)
+Defined in: [currency.ts:25](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L25)
 
 Represents a constructor that produces a currency instance.
 

--- a/docs/doubloons/namespaces/currencies/variables/registry.md
+++ b/docs/doubloons/namespaces/currencies/variables/registry.md
@@ -8,6 +8,6 @@
 
 > `const` **registry**: [`Registry`](../classes/Registry.md)
 
-Defined in: [currency.ts:65](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/currency.ts#L65)
+Defined in: [currency.ts:65](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/currency.ts#L65)
 
 The singleton registry instance.

--- a/docs/type-aliases/DoubloonToJSON.md
+++ b/docs/type-aliases/DoubloonToJSON.md
@@ -8,7 +8,7 @@
 
 > **DoubloonToJSON** = `object`
 
-Defined in: [Doubloon.ts:5](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L5)
+Defined in: [Doubloon.ts:5](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L5)
 
 ## Properties
 
@@ -16,12 +16,12 @@ Defined in: [Doubloon.ts:5](https://github.com/HitchPin/doubloon-ts/blob/d49b165
 
 > **canonical**: `string`
 
-Defined in: [Doubloon.ts:7](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L7)
+Defined in: [Doubloon.ts:7](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L7)
 
 ***
 
-### formatted
+### displayOnly
 
-> **formatted**: `string`
+> **displayOnly**: `string`
 
-Defined in: [Doubloon.ts:6](https://github.com/HitchPin/doubloon-ts/blob/d49b165a826cc7fe919f1929c5f92a4cf52ed6f4/src/Doubloon.ts#L6)
+Defined in: [Doubloon.ts:6](https://github.com/HitchPin/doubloon-ts/blob/3e0f3b652fb9655c4b1d15030b4525167c3704aa/src/Doubloon.ts#L6)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doubloons",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/Doubloon.ts
+++ b/src/Doubloon.ts
@@ -3,7 +3,7 @@ import { registry, type Currency, type CurrencyType } from './currency.js';
 import { uint8ArrayToBase64, base64ToUint8Array } from './b64/polyfill-core.js';
 
 export type DoubloonToJSON = {
-  formatted: string;
+  displayOnly: string;
   canonical: string;
 };
 
@@ -241,7 +241,7 @@ export class Doubloon<T extends Currency> {
     const enc = new TextEncoder().encode(json);
     return {
       canonical: uint8ArrayToBase64(enc),
-      formatted: this.currency.format(this.#value),
+      displayOnly: this.currency.format(this.#value),
     };
   }
   /**

--- a/test/Doubloon.spec.ts
+++ b/test/Doubloon.spec.ts
@@ -142,13 +142,13 @@ describe('Doubloon', () => {
     const x = new Doubloon<USD>(USD, '2.25');
     expect(x.toJSON()).to.be.eql({
       canonical: 'WyJVU0QiLCIyLjI1Il0=',
-      formatted: '$2.25',
+      displayOnly: '$2.25',
     });
   });
   test('Parses JSON envelope object', () => {
     const d = Doubloon.parse({
       canonical: "WyJVU0QiLCIyLjI1Il0=",
-      formatted: '$2.25',
+      displayOnly: '$2.25',
     });
     expect(d.toString()).to.be.eql('Doubloon<USD>(2.25)')
   });


### PR DESCRIPTION
…form with spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed Doubloon JSON field from “formatted” to “displayOnly” in outputs and parsing. Update integrations expecting this field.
- Documentation
  - Updated references and examples to reflect the new “displayOnly” field and refreshed source links.
- Tests
  - Adjusted test cases to validate “displayOnly” in JSON envelopes and outputs.
- Chores
  - Bumped package version to 1.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->